### PR TITLE
Update Cosign installer to v3 in workflow

### DIFF
--- a/.github/workflows/docker-build-sign.yml
+++ b/.github/workflows/docker-build-sign.yml
@@ -72,7 +72,7 @@ jobs:
       # Sign the image (only for main branch or tags)
       - name: Install Cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v2
+        uses: sigstore/cosign-installer@v3
 
       - name: Write Cosign key
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Bumps the sigstore/cosign-installer action from v2 to v3 in the docker-build-sign GitHub Actions workflow to use the latest version.